### PR TITLE
Bugfix/async top

### DIFF
--- a/src/Hyde.IntegrationTest/TableStorageProviderTest.cs
+++ b/src/Hyde.IntegrationTest/TableStorageProviderTest.cs
@@ -1736,7 +1736,7 @@ namespace TechSmith.Hyde.IntegrationTest
 
       [TestMethod]
       [TestCategory( "Integration" )]
-      public void GetCollection_ManyItemsInStore_TakeMethodReturnsProperAmount()
+      public void GetCollection_ManyItemsInStore_TopMethodReturnsProperAmount()
       {
          _tableStorageProvider.Add( _tableName, new TypeWithStringProperty
          {
@@ -1754,6 +1754,29 @@ namespace TechSmith.Hyde.IntegrationTest
 
          var result = _tableStorageProvider.GetCollection<TypeWithStringProperty>( _tableName, _partitionKey ).Top( 2 );
          Assert.AreEqual( 2, result.Count() );
+      }
+
+      [TestMethod]
+      [TestCategory( "Integration" )]
+      public void CreateQueryWithTopAsync_ManyItemsInStore_TopMethodReturnsProperAmount()
+      {
+         _tableStorageProvider.Add( _tableName, new TypeWithStringProperty
+         {
+            FirstType = "a"
+         }, _partitionKey, "a" );
+         _tableStorageProvider.Add( _tableName, new TypeWithStringProperty
+         {
+            FirstType = "b"
+         }, _partitionKey, "b" );
+         _tableStorageProvider.Add( _tableName, new TypeWithStringProperty
+         {
+            FirstType = "c"
+         }, _partitionKey, "c" );
+         _tableStorageProvider.Save();
+
+         var result = _tableStorageProvider.CreateQuery<TypeWithStringProperty>( _tableName ).PartitionKeyEquals( _partitionKey ).Top( 2 ).Async().Result;
+         Assert.AreEqual( 2, result.Count() );
+         Assert.AreEqual( "a", result.First().FirstType );
       }
 
       [TestMethod]

--- a/src/Hyde.Test/MemoryTableContextTest.cs
+++ b/src/Hyde.Test/MemoryTableContextTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TechSmith.Hyde.Common;
 using TechSmith.Hyde.Table;
@@ -360,6 +361,59 @@ namespace TechSmith.Hyde.Test
                               .PartitionKeyTo( "bcc" ).Inclusive();
 
          Assert.AreEqual( 2, result.Count() );
+      }
+
+      [TestMethod]
+      public void QueryByPartitionKeyRangeWithTop_ItemsInRange_ReturnsTopItem()
+      {
+         var items = new[]
+                     {
+                        new DecoratedItem { Id = "abc", Name = "123", Age = 42 },
+                        new DecoratedItem { Id = "abd", Name = "456", Age = 43 },
+                        new DecoratedItem { Id = "bcd", Name = "556", Age = 44 },
+                     };
+         foreach ( var item in items )
+         {
+            _context.AddNewItem( "table", TableItem.Create( item ) );
+         }
+         _context.Save( Execute.Individually );
+
+         var tsp = new InMemoryTableStorageProvider();
+         var result = _context.CreateQuery( "table", false )
+                              .PartitionKeyFrom( tsp.MinimumKeyValue ).Inclusive()
+                              .PartitionKeyTo( "bcc" ).Inclusive()
+                              .Top( 1 );
+
+         Assert.AreEqual( 1, result.Count() );
+         string actualName = result.Single().RowKey;
+         Assert.AreEqual( "123", actualName );
+      }
+
+      [TestMethod]
+      public void QueryAsyncByPartitionKeyRangeWithTop_ItemsInRange_ReturnsTopItem()
+      {
+         var items = new[]
+                     {
+                        new DecoratedItem { Id = "abc", Name = "123", Age = 42 },
+                        new DecoratedItem { Id = "abd", Name = "456", Age = 43 },
+                        new DecoratedItem { Id = "bcd", Name = "556", Age = 44 },
+                     };
+         foreach ( var item in items )
+         {
+            _context.AddNewItem( "table", TableItem.Create( item ) );
+         }
+         _context.Save( Execute.Individually );
+
+         var tsp = new InMemoryTableStorageProvider();
+         var result = _context.CreateQuery( "table", false )
+                              .PartitionKeyFrom( tsp.MinimumKeyValue ).Inclusive()
+                              .PartitionKeyTo( "bcc" ).Inclusive()
+                              .Top( 1 )
+                              .Async().Result;
+
+         Assert.AreEqual( 1, result.Count() );
+         string actualName = result.Single().RowKey;
+         Assert.AreEqual( "123", actualName );
       }
 
       [TestMethod]

--- a/src/Hyde/Common/IPartialResultTaskExtensions.cs
+++ b/src/Hyde/Common/IPartialResultTaskExtensions.cs
@@ -31,7 +31,7 @@ namespace TechSmith.Hyde.Common
             {
                aggregator = aggregator.Concat( antecedent.Result );
                var partialResult = antecedent.Result;
-               if ( partialResult.HasMoreResults )
+               if ( partialResult.HasMoreResults && !QueryHasBeenSatisfied( aggregator, partialResult.Query ) )
                {
                   MergeAndContinueIfNecessary<T>( antecedent.Result.GetNextAsync(), aggregator, overallCompletionSource );
                }
@@ -47,6 +47,11 @@ namespace TechSmith.Hyde.Common
             }
          }, TaskContinuationOptions.OnlyOnRanToCompletion );
          asyncResult.ContinueWith( ( Task faultedTask ) => faultedTask.Exception.Handle( overallCompletionSource.TrySetException ), TaskContinuationOptions.OnlyOnFaulted );
+      }
+
+      private static bool QueryHasBeenSatisfied<T>( IEnumerable<T> aggregator, QueryDescriptor query )
+      {
+         return query.TopCount.HasValue && aggregator.Count() >= query.TopCount.Value;
       }
    }
 }

--- a/src/Hyde/Table/Azure/AbstractAzureQuery.cs
+++ b/src/Hyde/Table/Azure/AbstractAzureQuery.cs
@@ -59,6 +59,8 @@ namespace TechSmith.Hyde.Table.Azure
             _segment = segment;
          }
 
+         public QueryDescriptor Query { get { return _parent._query; } }
+
          public bool HasMoreResults { get { return _segment.ContinuationToken != null; } }
 
          public Task<IPartialResult<T>> GetNextAsync()

--- a/src/Hyde/Table/IQuery.cs
+++ b/src/Hyde/Table/IQuery.cs
@@ -51,6 +51,7 @@ namespace TechSmith.Hyde.Table
       Task<IPartialResult<T>> GetNextAsync();
       IPartialResult<T> GetNext();
       bool HasMoreResults { get; }
+      QueryDescriptor Query { get; }
    }
 
    public interface IBoundChoice<T>

--- a/src/Hyde/Table/Memory/AbstractMemoryQuery.cs
+++ b/src/Hyde/Table/Memory/AbstractMemoryQuery.cs
@@ -40,6 +40,8 @@ namespace TechSmith.Hyde.Table.Memory
 
          public bool HasMoreResults { get { return false; } }
 
+         public QueryDescriptor Query { get { return _parent._query; } }
+
          public IEnumerator<T> GetEnumerator()
          {
             return _parent.GetEnumerator();


### PR DESCRIPTION
Fixes a bug where the Top value would be ignored if you used the `.Async()` method of the query.