### PR TITLE
always call endasync when doing an async get

### DIFF
--- a/src/Hyde/Table/TableStorageProvider.cs
+++ b/src/Hyde/Table/TableStorageProvider.cs
@@ -111,8 +111,7 @@ namespace TechSmith.Hyde.Table
                         .PartitionKeyEquals( partitionKey )
                         .RowKeyEquals( rowKey )
                         .PartialAsync()
-                        .ContinueWith( task => EndGetAsync( task, partitionKey, rowKey ),
-                                       TaskContinuationOptions.OnlyOnRanToCompletion );
+                        .ContinueWith( task => EndGetAsync( task, partitionKey, rowKey ) );
       }
 
       private static T EndGetAsync<T>( Task<IPartialResult<T>> task, string pk, string rk )


### PR DESCRIPTION
This implementation caused us to create tasks that would never return
if they were faulted, resulting in deadlock any time calling code
waited on one of these.