### PR TITLE
Retarget .net standard 1.6 and full .net 4.6

### DIFF
--- a/src/Hyde/Hyde.csproj
+++ b/src/Hyde/Hyde.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>TechSmith.Hyde</AssemblyTitle>
     <VersionPrefix>9.0.0</VersionPrefix>
     <Authors>TechSmith Corporation</Authors>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>TechSmith.Hyde</AssemblyName>
     <PackageId>TechSmith.Hyde</PackageId>
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="Microsoft.Data.Edm" Version="5.8.2" />
     <PackageReference Include="Microsoft.Data.OData" Version="5.8.2" />
     <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.2" />


### PR DESCRIPTION
* Previously we targeted just .net standard 1.5. In testing it seems that we can be more compatible by targeting both .net 4.6 full and .net standard 1.6.