### PR TITLE
Fix deadlock issue in GetAsync

### DIFF
--- a/src/Hyde/Common/IPartialResultTaskExtensions.cs
+++ b/src/Hyde/Common/IPartialResultTaskExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using TechSmith.Hyde.Table;
@@ -15,41 +14,23 @@ namespace TechSmith.Hyde.Common
       /// <typeparam name="T">The type of the result being returned.</typeparam>
       /// <param name="asyncResult">The result being flattened.</param>
       /// <returns></returns>
-      public static Task<IEnumerable<T>> FlattenAsync<T>( this Task<IPartialResult<T>> asyncResult )
+      public static async Task<IEnumerable<T>> FlattenAsync<T>( this Task<IPartialResult<T>> asyncResult )
       {
-         var overallCompletionSource = new TaskCompletionSource<IEnumerable<T>>();
-         IEnumerable<T> resultSet = Enumerable.Empty<T>();
-         MergeAndContinueIfNecessary( asyncResult, resultSet, overallCompletionSource );
-         return overallCompletionSource.Task;
+         var resultSet = new List<T>();
+         await MergeAndContinueIfNecessaryAsync( await asyncResult.ConfigureAwait( false ), resultSet ).ConfigureAwait( false );
+         return resultSet;
       }
 
-      private static void MergeAndContinueIfNecessary<T>( Task<IPartialResult<T>> asyncResult, IEnumerable<T> aggregator, TaskCompletionSource<IEnumerable<T>> overallCompletionSource )
+      private static async Task MergeAndContinueIfNecessaryAsync<T>( IPartialResult<T> partialResult, List<T> aggregator )
       {
-         asyncResult.ContinueWith( antecedent =>
+         aggregator.AddRange( partialResult );
+         if ( partialResult.HasMoreResults && !QueryHasBeenSatisfied( aggregator, partialResult.Query ) )
          {
-            try
-            {
-               aggregator = aggregator.Concat( antecedent.Result );
-               var partialResult = antecedent.Result;
-               if ( partialResult.HasMoreResults && !QueryHasBeenSatisfied( aggregator, partialResult.Query ) )
-               {
-                  MergeAndContinueIfNecessary<T>( antecedent.Result.GetNextAsync(), aggregator, overallCompletionSource );
-               }
-               else
-               {
-                  overallCompletionSource.SetResult( aggregator );
-               }
-            }
-            catch ( Exception e )
-            {
-               // Catch synchronous exceptions in our continuation and propagate them.
-               overallCompletionSource.SetException( e );
-            }
-         }, TaskContinuationOptions.OnlyOnRanToCompletion );
-         asyncResult.ContinueWith( ( Task faultedTask ) => faultedTask.Exception.Handle( overallCompletionSource.TrySetException ), TaskContinuationOptions.OnlyOnFaulted );
+            await MergeAndContinueIfNecessaryAsync<T>( await partialResult.GetNextAsync().ConfigureAwait( false ), aggregator ).ConfigureAwait( false );
+         }
       }
 
-      private static bool QueryHasBeenSatisfied<T>( IEnumerable<T> aggregator, QueryDescriptor query )
+      private static bool QueryHasBeenSatisfied<T>( List<T> aggregator, QueryDescriptor query )
       {
          return query.TopCount.HasValue && aggregator.Count() >= query.TopCount.Value;
       }

--- a/src/Hyde/Table/Azure/AbstractAzureQuery.cs
+++ b/src/Hyde/Table/Azure/AbstractAzureQuery.cs
@@ -53,13 +53,13 @@ namespace TechSmith.Hyde.Table.Azure
 
          public bool HasMoreResults { get { return _segment.ContinuationToken != null; } }
 
-         public Task<IPartialResult<T>> GetNextAsync()
+         public async Task<IPartialResult<T>> GetNextAsync()
          {
             if ( !HasMoreResults )
             {
                throw new InvalidOperationException( "Cannot get next when there are no more results" );
             }
-            return _parent.GetPartialResultAsync( _query, _segment.ContinuationToken );
+            return await _parent.GetPartialResultAsync( _query, _segment.ContinuationToken ).ConfigureAwait( false );
          }
 
          public IEnumerator<T> GetEnumerator()

--- a/src/Hyde/Table/Azure/AzureTableEntityTableContext.cs
+++ b/src/Hyde/Table/Azure/AzureTableEntityTableContext.cs
@@ -98,11 +98,11 @@ namespace TechSmith.Hyde.Table.Azure
          _operations.Enqueue( new ExecutableTableOperation( tableName, operation, TableOperationType.Delete, tableItem.PartitionKey, tableItem.RowKey ) );
       }
 
-      public Task SaveAsync( Execute executeMethod )
+      public async Task SaveAsync( Execute executeMethod )
       {
          if ( !_operations.Any() )
          {
-            return Task.FromResult( 0 );
+            return;
          }
 
          try
@@ -111,15 +111,18 @@ namespace TechSmith.Hyde.Table.Azure
             {
                case Execute.Individually:
                {
-                  return SaveIndividualAsync( new List<ExecutableTableOperation>( _operations ) );
+                  await SaveIndividualAsync( new List<ExecutableTableOperation>( _operations ) ).ConfigureAwait( false );
+                  return;
                }
                case Execute.InBatches:
                {
-                  return SaveBatchAsync( new List<ExecutableTableOperation>( _operations ) );
+                  await SaveBatchAsync( new List<ExecutableTableOperation>( _operations ) ).ConfigureAwait( false );
+                  return;
                }
                case Execute.Atomically:
                {
-                  return SaveAtomicallyAsync( new List<ExecutableTableOperation>( _operations ) );
+                  await SaveAtomicallyAsync( new List<ExecutableTableOperation>( _operations ) ).ConfigureAwait( false );
+                  return;
                }
                default:
                {
@@ -266,7 +269,7 @@ namespace TechSmith.Hyde.Table.Azure
          var batchOperation = ValidateAndCreateBatchOperation( operations, out table );
          if ( batchOperation.Count == 0 )
          {
-            return Task.FromResult( 0 );
+            return Task.CompletedTask;
          }
 
          return HandleTableStorageExceptions( false, table.ExecuteBatchAsync( batchOperation, _retriableTableRequest, null ) );

--- a/src/Hyde/Table/AzureTableStorageProvider.cs
+++ b/src/Hyde/Table/AzureTableStorageProvider.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Concurrent;
-using System.Net;
 using TechSmith.Hyde.Table.Azure;
 
 namespace TechSmith.Hyde.Table

--- a/src/Hyde/Table/Memory/MemoryTableContext.cs
+++ b/src/Hyde/Table/Memory/MemoryTableContext.cs
@@ -152,7 +152,7 @@ namespace TechSmith.Hyde.Table.Memory
          _pendingActions = new ConcurrentQueue<TableAction>();
 
          SaveInternal( executeMethod, pendingActions );
-         return Task.FromResult( 0 );
+         return Task.CompletedTask;
       }
 
       private void SaveInternal( Execute executeMethod, TableAction[] actions )

--- a/src/Hyde/Table/TableStorageProvider.cs
+++ b/src/Hyde/Table/TableStorageProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using TechSmith.Hyde.Common;
@@ -140,14 +139,14 @@ namespace TechSmith.Hyde.Table
          return _context.CreateQuery( tableName, ShouldIncludeETagWithDynamics );
       }
 
-      public Task SaveAsync()
+      public async Task SaveAsync()
       {
-         return SaveAsync( Execute.Individually );
+         await SaveAsync( Execute.Individually ).ConfigureAwait( false );
       }
 
-      public Task SaveAsync( Execute executeMethod )
+      public async Task SaveAsync( Execute executeMethod )
       {
-         return _context.SaveAsync( executeMethod );
+         await _context.SaveAsync( executeMethod ).ConfigureAwait( false );
       }
 
       /// <summary>


### PR DESCRIPTION
GetAsync was using a blocking wait in the Task continuation (used `.Result`).  Fixed the deadlock issue and also updated other code to avoid Task continuations and eliding awaits.